### PR TITLE
fix imaging binding

### DIFF
--- a/valkka/onvif/base.py
+++ b/valkka/onvif/base.py
@@ -168,7 +168,7 @@ class Imaging(OnVif):
     wsdl_file = getWSDLPath("imaging-20.wsdl")
     namespace = "http://www.onvif.org/ver20/imaging/wsdl"
     sub_xaddr = "Imaging"
-    port      = "ImagingPort"
+    port      = "ImagingBinding"
 
 
 class DeviceIO(OnVif):


### PR DESCRIPTION
The fix for the mislabeled binding in `base.py`.